### PR TITLE
Fixes #8 empty referer YouTube error

### DIFF
--- a/inc/EmbedYoutubeLiveStreaming.php
+++ b/inc/EmbedYoutubeLiveStreaming.php
@@ -337,6 +337,7 @@ class EmbedYoutubeLiveStreaming {
         curl_setopt( $curl, CURLOPT_RETURNTRANSFER, true );
         curl_setopt( $curl, CURLOPT_CAINFO, plugin_dir_path( __FILE__ ) . 'cacert.pem' );
         curl_setopt( $curl, CURLOPT_CAPATH, plugin_dir_path( __FILE__ ) );
+        curl_setopt( $curl, CURLOPT_REFERER, home_url() );
         $this->jsonResponse = curl_exec( $curl );
         curl_close( $curl );
 


### PR DESCRIPTION
Added home_url() as the curl referer when calling YouTube so that API keys can be restricted by referer.